### PR TITLE
1.24.9

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -1,9 +1,10 @@
+import asyncio
 import inspect
 import itertools
 import typing
 import warnings
 
-from .. import helpers, utils, errors, hints
+from .. import helpers, utils, errors, hints, events
 from ..requestiter import RequestIter
 from ..tl import types, functions
 
@@ -341,17 +342,17 @@ class MessageMethods:
 
     def iter_messages(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         limit: float = None,
         *,
-        offset_date: "hints.DateLike" = None,
+        offset_date: hints.DateLike = None,
         offset_id: int = 0,
         max_id: int = 0,
         min_id: int = 0,
         add_offset: int = 0,
         search: str = None,
         filter: "typing.Union[types.TypeMessagesFilter, typing.Type[types.TypeMessagesFilter]]" = None,
-        from_user: "hints.EntityLike" = None,
+        from_user: hints.EntityLike = None,
         wait_time: float = None,
         ids: "typing.Union[int, typing.Sequence[int]]" = None,
         reverse: bool = False,
@@ -549,9 +550,7 @@ class MessageMethods:
             scheduled=scheduled,
         )
 
-    async def get_messages(
-        self: "TelegramClient", *args, **kwargs
-    ) -> "hints.TotalList":
+    async def get_messages(self: "TelegramClient", *args, **kwargs) -> hints.TotalList:
         """
         Same as `iter_messages()`, but returns a
         `TotalList <telethon.helpers.TotalList>` instead.
@@ -608,7 +607,7 @@ class MessageMethods:
 
     async def _get_comment_data(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         message: "typing.Union[int, types.Message]",
     ):
         r = await self(
@@ -622,8 +621,8 @@ class MessageMethods:
 
     async def send_message(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
-        message: "hints.MessageLike" = "",
+        entity: hints.EntityLike,
+        message: hints.MessageLike = "",
         *,
         reply_to: "typing.Union[int, types.Message]" = None,
         attributes: "typing.Sequence[types.TypeDocumentAttribute]" = None,
@@ -633,14 +632,14 @@ class MessageMethods:
         ] = None,
         link_preview: bool = True,
         file: "typing.Union[hints.FileLike, typing.Sequence[hints.FileLike]]" = None,
-        thumb: "hints.FileLike" = None,
+        thumb: hints.FileLike = None,
         force_document: bool = False,
         clear_draft: bool = False,
-        buttons: "hints.MarkupLike" = None,
+        buttons: hints.MarkupLike = None,
         silent: bool = None,
         background: bool = None,
         supports_streaming: bool = False,
-        schedule: "hints.DateLike" = None,
+        schedule: hints.DateLike = None,
         comment_to: "typing.Union[int, types.Message]" = None
     ) -> "types.Message":
         """
@@ -918,15 +917,15 @@ class MessageMethods:
 
     async def forward_messages(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         messages: "typing.Union[hints.MessageIDLike, typing.Sequence[hints.MessageIDLike]]",
-        from_peer: "hints.EntityLike" = None,
+        from_peer: hints.EntityLike = None,
         *,
         background: bool = None,
         with_my_score: bool = None,
         silent: bool = None,
         as_album: bool = None,
-        schedule: "hints.DateLike" = None
+        schedule: hints.DateLike = None
     ) -> "typing.Sequence[types.Message]":
         """
         Forwards the given messages to the specified entity.
@@ -1050,7 +1049,7 @@ class MessageMethods:
     async def edit_message(
         self: "TelegramClient",
         entity: "typing.Union[hints.EntityLike, types.Message]",
-        message: "hints.MessageLike" = None,
+        message: hints.MessageLike = None,
         text: str = None,
         *,
         parse_mode: str = (),
@@ -1059,12 +1058,12 @@ class MessageMethods:
             typing.List[types.TypeMessageEntity]
         ] = None,
         link_preview: bool = True,
-        file: "hints.FileLike" = None,
-        thumb: "hints.FileLike" = None,
+        file: hints.FileLike = None,
+        thumb: hints.FileLike = None,
         force_document: bool = False,
-        buttons: "hints.MarkupLike" = None,
+        buttons: hints.MarkupLike = None,
         supports_streaming: bool = False,
-        schedule: "hints.DateLike" = None
+        schedule: hints.DateLike = None
     ) -> "types.Message":
         """
         Edits the given message to change its text or media.
@@ -1229,7 +1228,7 @@ class MessageMethods:
 
     async def delete_messages(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         message_ids: "typing.Union[hints.MessageIDLike, typing.Sequence[hints.MessageIDLike]]",
         *,
         revoke: bool = True
@@ -1316,7 +1315,7 @@ class MessageMethods:
 
     async def send_read_acknowledge(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         message: "typing.Union[hints.MessageIDLike, typing.Sequence[hints.MessageIDLike]]" = None,
         *,
         max_id: int = None,
@@ -1401,7 +1400,7 @@ class MessageMethods:
 
     async def pin_message(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         message: "typing.Optional[hints.MessageIDLike]",
         *,
         notify: bool = False,
@@ -1439,12 +1438,16 @@ class MessageMethods:
                 await client.pin_message(chat, message, notify=True)
         """
         return await self._pin(
-            entity, message, unpin=False, notify=notify, pm_oneside=pm_oneside
+            entity,
+            message,
+            unpin=False,
+            notify=notify,
+            pm_oneside=pm_oneside,
         )
 
     async def unpin_message(
         self: "TelegramClient",
-        entity: "hints.EntityLike",
+        entity: hints.EntityLike,
         message: "typing.Optional[hints.MessageIDLike]" = None,
         *,
         notify: bool = False
@@ -1498,30 +1501,39 @@ class MessageMethods:
         # Pinning a message that doesn't exist would RPC-error earlier
         return self._get_response_message(request, result, entity)
 
+    async def report_reaction(
+        self: "TelegramClient",
+        peer: hints.EntityLike,
+        id: int,
+        reaction_peer: hints.EntityLike,
+    ) -> bool:
+        return await self(
+            functions.messages.ReportReactionRequest(peer, id, reaction_peer)
+        )
+
     async def send_reaction(
-        self: 'TelegramClient',
-        entity: 'hints.DialogLike',
-        message: 'hints.MessageIDLike',
-        reaction: typing.Optional[str] = None,
-        big: bool = False
+        self: "TelegramClient",
+        entity: hints.DialogLike,
+        message: hints.MessageIDLike,
+        reaction: typing.Optional[hints.Reaction] = None,
+        big: bool = False,
+        add_to_recent: bool = False,
     ):
+        reaction = utils.convert_reaction(reaction)
         message = utils.get_message_id(message) or 0
         if not reaction:
             get_default_request = functions.help.GetAppConfigRequest()
             app_config = await self(get_default_request)
             reaction = (
-                next(
-                    (
-                        y for y in app_config.value
-                        if "reactions_default" in y.key
-                    )
-                )
+                next((y for y in app_config.value if "reactions_default" in y.key))
             ).value.value
+
         request = functions.messages.SendReactionRequest(
             big=big,
             peer=entity,
             msg_id=message,
-            reaction=reaction
+            reaction=reaction,
+            add_to_recent=add_to_recent,
         )
         result = await self(request)
         for update in result.updates:
@@ -1530,14 +1542,70 @@ class MessageMethods:
             if isinstance(update, types.UpdateEditMessage):
                 return update.message.reactions
 
-    async def set_quick_reaction(
-        self: 'TelegramClient',
-        reaction: str
-    ):
+    async def set_quick_reaction(self: "TelegramClient", reaction: hints.Reaction):
         request = functions.messages.SetDefaultReactionRequest(
-            reaction=reaction
+            reaction=utils.convert_reaction(reaction)
         )
         return await self(request)
+
+    async def transcribe(
+        self: "TelegramClient",
+        peer: hints.EntityLike,
+        message: hints.MessageIDLike,
+        timeout: int = 15,
+    ) -> typing.Optional[str]:
+        result = await self(
+            functions.messages.TranscribeAudioRequest(
+                peer,
+                utils.get_message_id(message),
+            )
+        )
+
+        transcription_result = None
+
+        event = asyncio.Event()
+
+        @self.on(events.Raw(types.UpdateTranscribedAudio))
+        async def handler(update):
+            nonlocal result, transcription_result
+            if update.transcription_id != result.transcription_id or update.pending:
+                return
+
+            transcription_result = update.text
+            event.set()
+            raise events.StopPropagation
+
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+        except Exception:
+            return None
+
+        return transcription_result
+
+    async def translate(
+        self: "TelegramClient",
+        peer: hints.EntityLike,
+        message: hints.MessageIDLike,
+        to_lang: str,
+        from_lang: typing.Optional[str] = None,
+    ) -> str:
+        msg_id = utils.get_message_id(message) or 0
+        if not msg_id:
+            return None
+
+        if not isinstance(message, types.Message):
+            message = (await self.get_messages(peer, ids=[msg_id]))[0]
+
+        result = await self(
+            functions.messages.TranslateTextRequest(
+                peer=peer,
+                msg_id=msg_id,
+                text=message.raw_text,
+                to_lang=to_lang,
+                from_lang=from_lang,
+            )
+        )
+        return getattr(result, "text", None) or ""
 
     # endregion
 

--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -638,4 +638,17 @@ class UserMethods:
 
         return types.InputNotifyPeer(await self.get_input_entity(notify))
 
+    async def set_status(
+        self: "TelegramClient",
+        document_id: int,
+        until: typing.Optional[int] = None,
+    ) -> bool:
+        return await self(
+            functions.account.UpdateEmojiStatusRequest(
+                types.EmojiStatusUntil(document_id, until)
+                if until
+                else types.EmojiStatus(document_id)
+            )
+        )
+
     # endregion

--- a/telethon/hints.py
+++ b/telethon/hints.py
@@ -17,6 +17,8 @@ EntityLike = typing.Union[
 ]
 EntitiesLike = typing.Union[EntityLike, typing.Sequence[EntityLike]]
 
+DialogLike = EntityLike
+
 ButtonLike = typing.Union[types.TypeKeyboardButton, custom.Button]
 MarkupLike = typing.Union[
     types.TypeReplyMarkup,
@@ -56,3 +58,16 @@ MessageLike = typing.Union[str, types.Message]
 MessageIDLike = typing.Union[int, types.Message, types.TypeInputMessage]
 
 ProgressCallback = typing.Callable[[int, int], None]
+
+Reaction = typing.Optional[
+    typing.Union[
+        str,
+        typing.List[str],
+        int,
+        typing.List[int],
+        types.ReactionEmoji,
+        typing.List[types.ReactionEmoji],
+        types.ReactionCustomEmoji,
+        typing.List[types.ReactionCustomEmoji],
+    ]
+]

--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Optional, List, TYPE_CHECKING
 from datetime import datetime
 from .chatgetter import ChatGetter
@@ -868,7 +869,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
         data=None,
         share_phone=None,
         share_geo=None,
-        password=None
+        password=None,
     ):
         """
         Calls :tl:`SendVote` with the specified poll option
@@ -1096,7 +1097,65 @@ class Message(ChatGetter, SenderGetter, TLObject):
                 await self.get_input_chat(), self.id
             )
 
-    async def react(self, reaction=None):
+    async def translate(
+        self,
+        to_lang: str,
+        from_lang: typing.Optional[str] = None,
+    ):
+        """
+        Translates the message using Google Translate.
+
+        Args:
+            to_lang (`str`):
+                The language to translate to. Must be a valid language code
+                (e.g. ``en``, ``es``, ``fr``, etc).
+
+            from_lang (`str`):
+                The language to translate from. If not set, it will be
+                automatically detected.
+
+        Returns:
+            `str`: The translated text.
+
+        Example:
+            .. code-block:: python
+
+                # Translate the message to Spanish
+                translated = await message.translate('es')
+
+                # Translate the message from English to Spanish
+                translated = await message.translate('es', 'en')
+        """
+        if not self._client:
+            return
+
+        return await self._client.translate(self.peer_id, self, to_lang, from_lang)
+
+    async def transcribe(self) -> typing.Optional[str]:
+        """
+        Transcribes the message using native Telegram feature.
+
+        Returns:
+            `str`: The transcribed text.
+
+        Example:
+            .. code-block:: python
+
+                # Transcribe the message
+                transcribed = await message.transcribe()
+        """
+
+        if not self._client:
+            return
+
+        return await self._client.transcribe(self.peer_id, self)
+
+    async def react(
+        self,
+        reaction: "typing.Optional[hints.Reaction]" = None,  # type: ignore
+        big: bool = False,
+        add_to_recent: bool = False,
+    ):
         """
         Reacts on the given message. Shorthand for
         `telethon.client.messages.MessageMethods.send_reaction`
@@ -1106,7 +1165,9 @@ class Message(ChatGetter, SenderGetter, TLObject):
             return await self._client.send_reaction(
                 await self.get_input_chat(),
                 self.id,
-                reaction
+                reaction,
+                big=big,
+                add_to_recent=add_to_recent,
             )
 
     # endregion Public Methods

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.24.8'
+__version__ = '1.24.9'

--- a/telethon_generator/data/api.tl
+++ b/telethon_generator/data/api.tl
@@ -110,7 +110,7 @@ storage.fileMp4#b3cea0e4 = storage.FileType;
 storage.fileWebp#1081464c = storage.FileType;
 
 userEmpty#d3bc4b7a id:long = User;
-user#3ff6ecb0 flags:# self:flags.10?true contact:flags.11?true mutual_contact:flags.12?true deleted:flags.13?true bot:flags.14?true bot_chat_history:flags.15?true bot_nochats:flags.16?true verified:flags.17?true restricted:flags.18?true min:flags.20?true bot_inline_geo:flags.21?true support:flags.23?true scam:flags.24?true apply_min_photo:flags.25?true fake:flags.26?true bot_attach_menu:flags.27?true premium:flags.28?true attach_menu_enabled:flags.29?true id:long access_hash:flags.0?long first_name:flags.1?string last_name:flags.2?string username:flags.3?string phone:flags.4?string photo:flags.5?UserProfilePhoto status:flags.6?UserStatus bot_info_version:flags.14?int restriction_reason:flags.18?Vector<RestrictionReason> bot_inline_placeholder:flags.19?string lang_code:flags.22?string = User;
+user#5d99adee flags:# self:flags.10?true contact:flags.11?true mutual_contact:flags.12?true deleted:flags.13?true bot:flags.14?true bot_chat_history:flags.15?true bot_nochats:flags.16?true verified:flags.17?true restricted:flags.18?true min:flags.20?true bot_inline_geo:flags.21?true support:flags.23?true scam:flags.24?true apply_min_photo:flags.25?true fake:flags.26?true bot_attach_menu:flags.27?true premium:flags.28?true attach_menu_enabled:flags.29?true id:long access_hash:flags.0?long first_name:flags.1?string last_name:flags.2?string username:flags.3?string phone:flags.4?string photo:flags.5?UserProfilePhoto status:flags.6?UserStatus bot_info_version:flags.14?int restriction_reason:flags.18?Vector<RestrictionReason> bot_inline_placeholder:flags.19?string lang_code:flags.22?string emoji_status:flags.30?EmojiStatus = User;
 
 userProfilePhotoEmpty#4f11bae1 = UserProfilePhoto;
 userProfilePhoto#82d1f706 flags:# has_video:flags.0?true photo_id:long stripped_thumb:flags.1?bytes dc_id:int = UserProfilePhoto;
@@ -128,8 +128,8 @@ chatForbidden#6592a1a7 id:long title:string = Chat;
 channel#8261ac61 flags:# creator:flags.0?true left:flags.2?true broadcast:flags.5?true verified:flags.7?true megagroup:flags.8?true restricted:flags.9?true signatures:flags.11?true min:flags.12?true scam:flags.19?true has_link:flags.20?true has_geo:flags.21?true slowmode_enabled:flags.22?true call_active:flags.23?true call_not_empty:flags.24?true fake:flags.25?true gigagroup:flags.26?true noforwards:flags.27?true join_to_send:flags.28?true join_request:flags.29?true id:long access_hash:flags.13?long title:string username:flags.6?string photo:ChatPhoto date:int restriction_reason:flags.9?Vector<RestrictionReason> admin_rights:flags.14?ChatAdminRights banned_rights:flags.15?ChatBannedRights default_banned_rights:flags.18?ChatBannedRights participants_count:flags.17?int = Chat;
 channelForbidden#17d493d5 flags:# broadcast:flags.5?true megagroup:flags.8?true id:long access_hash:long title:string until_date:flags.16?int = Chat;
 
-chatFull#d18ee226 flags:# can_set_username:flags.7?true has_scheduled:flags.8?true id:long about:string participants:ChatParticipants chat_photo:flags.2?Photo notify_settings:PeerNotifySettings exported_invite:flags.13?ExportedChatInvite bot_info:flags.3?Vector<BotInfo> pinned_msg_id:flags.6?int folder_id:flags.11?int call:flags.12?InputGroupCall ttl_period:flags.14?int groupcall_default_join_as:flags.15?Peer theme_emoticon:flags.16?string requests_pending:flags.17?int recent_requesters:flags.17?Vector<long> available_reactions:flags.18?Vector<string> = ChatFull;
-channelFull#ea68a619 flags:# can_view_participants:flags.3?true can_set_username:flags.6?true can_set_stickers:flags.7?true hidden_prehistory:flags.10?true can_set_location:flags.16?true has_scheduled:flags.19?true can_view_stats:flags.20?true blocked:flags.22?true flags2:# can_delete_channel:flags2.0?true id:long about:string participants_count:flags.0?int admins_count:flags.1?int kicked_count:flags.2?int banned_count:flags.2?int online_count:flags.13?int read_inbox_max_id:int read_outbox_max_id:int unread_count:int chat_photo:Photo notify_settings:PeerNotifySettings exported_invite:flags.23?ExportedChatInvite bot_info:Vector<BotInfo> migrated_from_chat_id:flags.4?long migrated_from_max_id:flags.4?int pinned_msg_id:flags.5?int stickerset:flags.8?StickerSet available_min_id:flags.9?int folder_id:flags.11?int linked_chat_id:flags.14?long location:flags.15?ChannelLocation slowmode_seconds:flags.17?int slowmode_next_send_date:flags.18?int stats_dc:flags.12?int pts:int call:flags.21?InputGroupCall ttl_period:flags.24?int pending_suggestions:flags.25?Vector<string> groupcall_default_join_as:flags.26?Peer theme_emoticon:flags.27?string requests_pending:flags.28?int recent_requesters:flags.28?Vector<long> default_send_as:flags.29?Peer available_reactions:flags.30?Vector<string> = ChatFull;
+chatFull#c9d31138 flags:# can_set_username:flags.7?true has_scheduled:flags.8?true id:long about:string participants:ChatParticipants chat_photo:flags.2?Photo notify_settings:PeerNotifySettings exported_invite:flags.13?ExportedChatInvite bot_info:flags.3?Vector<BotInfo> pinned_msg_id:flags.6?int folder_id:flags.11?int call:flags.12?InputGroupCall ttl_period:flags.14?int groupcall_default_join_as:flags.15?Peer theme_emoticon:flags.16?string requests_pending:flags.17?int recent_requesters:flags.17?Vector<long> available_reactions:flags.18?ChatReactions = ChatFull;
+channelFull#f2355507 flags:# can_view_participants:flags.3?true can_set_username:flags.6?true can_set_stickers:flags.7?true hidden_prehistory:flags.10?true can_set_location:flags.16?true has_scheduled:flags.19?true can_view_stats:flags.20?true blocked:flags.22?true flags2:# can_delete_channel:flags2.0?true id:long about:string participants_count:flags.0?int admins_count:flags.1?int kicked_count:flags.2?int banned_count:flags.2?int online_count:flags.13?int read_inbox_max_id:int read_outbox_max_id:int unread_count:int chat_photo:Photo notify_settings:PeerNotifySettings exported_invite:flags.23?ExportedChatInvite bot_info:Vector<BotInfo> migrated_from_chat_id:flags.4?long migrated_from_max_id:flags.4?int pinned_msg_id:flags.5?int stickerset:flags.8?StickerSet available_min_id:flags.9?int folder_id:flags.11?int linked_chat_id:flags.14?long location:flags.15?ChannelLocation slowmode_seconds:flags.17?int slowmode_next_send_date:flags.18?int stats_dc:flags.12?int pts:int call:flags.21?InputGroupCall ttl_period:flags.24?int pending_suggestions:flags.25?Vector<string> groupcall_default_join_as:flags.26?Peer theme_emoticon:flags.27?string requests_pending:flags.28?int recent_requesters:flags.28?Vector<long> default_send_as:flags.29?Peer available_reactions:flags.30?ChatReactions = ChatFull;
 
 chatParticipant#c02d4007 user_id:long inviter_id:long date:int = ChatParticipant;
 chatParticipantCreator#e46bcee4 user_id:long = ChatParticipant;
@@ -324,7 +324,7 @@ updateChannelMessageViews#f226ac08 channel_id:long id:int views:int = Update;
 updateChatParticipantAdmin#d7ca61a2 chat_id:long user_id:long is_admin:Bool version:int = Update;
 updateNewStickerSet#688a30aa stickerset:messages.StickerSet = Update;
 updateStickerSetsOrder#bb2d201 flags:# masks:flags.0?true emojis:flags.1?true order:Vector<long> = Update;
-updateStickerSets#43ae3dec = Update;
+updateStickerSets#31c24808 flags:# masks:flags.0?true emojis:flags.1?true = Update;
 updateSavedGifs#9375341e = Update;
 updateBotInlineQuery#496f379c flags:# query_id:long user_id:long query:string geo:flags.0?GeoPoint peer_type:flags.1?InlineQueryPeerType offset:string = Update;
 updateBotInlineSend#12f12a07 flags:# user_id:long query:string geo:flags.0?GeoPoint id:string msg_id:flags.1?InputBotInlineMessageID = Update;
@@ -393,6 +393,10 @@ updateBotMenuButton#14b85813 bot_id:long button:BotMenuButton = Update;
 updateSavedRingtones#74d8be99 = Update;
 updateTranscribedAudio#84cd5a flags:# pending:flags.0?true peer:Peer msg_id:int transcription_id:long text:string = Update;
 updateReadFeaturedEmojiStickers#fb4c496c = Update;
+updateUserEmojiStatus#28373599 user_id:long emoji_status:EmojiStatus = Update;
+updateRecentEmojiStatuses#30f443db = Update;
+updateRecentReactions#6f7863f4 = Update;
+updateMoveStickerSetToTop#86fccf85 flags:# masks:flags.0?true emojis:flags.1?true stickerset:long = Update;
 
 updates.state#a56c2a3e pts:int qts:int date:int seq:int unread_count:int = updates.State;
 
@@ -419,7 +423,7 @@ upload.fileCdnRedirect#f18cda44 dc_id:int file_token:bytes encryption_key:bytes 
 
 dcOption#18b7a10d flags:# ipv6:flags.0?true media_only:flags.1?true tcpo_only:flags.2?true cdn:flags.3?true static:flags.4?true this_port_only:flags.5?true id:int ip_address:string port:int secret:flags.10?bytes = DcOption;
 
-config#330b4067 flags:# phonecalls_enabled:flags.1?true default_p2p_contacts:flags.3?true preload_featured_stickers:flags.4?true ignore_phone_entities:flags.5?true revoke_pm_inbox:flags.6?true blocked_mode:flags.8?true pfs_enabled:flags.13?true force_try_ipv6:flags.14?true date:int expires:int test_mode:Bool this_dc:int dc_options:Vector<DcOption> dc_txt_domain_name:string chat_size_max:int megagroup_size_max:int forwarded_count_max:int online_update_period_ms:int offline_blur_timeout_ms:int offline_idle_timeout_ms:int online_cloud_timeout_ms:int notify_cloud_delay_ms:int notify_default_delay_ms:int push_chat_period_ms:int push_chat_limit:int saved_gifs_limit:int edit_time_limit:int revoke_time_limit:int revoke_pm_time_limit:int rating_e_decay:int stickers_recent_limit:int stickers_faved_limit:int channels_read_media_period:int tmp_sessions:flags.0?int pinned_dialogs_count_max:int pinned_infolder_count_max:int call_receive_timeout_ms:int call_ring_timeout_ms:int call_connect_timeout_ms:int call_packet_timeout_ms:int me_url_prefix:string autoupdate_url_prefix:flags.7?string gif_search_username:flags.9?string venue_search_username:flags.10?string img_search_username:flags.11?string static_maps_provider:flags.12?string caption_length_max:int message_length_max:int webfile_dc_id:int suggested_lang_code:flags.2?string lang_pack_version:flags.2?int base_lang_pack_version:flags.2?int = Config;
+config#232566ac flags:# phonecalls_enabled:flags.1?true default_p2p_contacts:flags.3?true preload_featured_stickers:flags.4?true ignore_phone_entities:flags.5?true revoke_pm_inbox:flags.6?true blocked_mode:flags.8?true pfs_enabled:flags.13?true force_try_ipv6:flags.14?true date:int expires:int test_mode:Bool this_dc:int dc_options:Vector<DcOption> dc_txt_domain_name:string chat_size_max:int megagroup_size_max:int forwarded_count_max:int online_update_period_ms:int offline_blur_timeout_ms:int offline_idle_timeout_ms:int online_cloud_timeout_ms:int notify_cloud_delay_ms:int notify_default_delay_ms:int push_chat_period_ms:int push_chat_limit:int saved_gifs_limit:int edit_time_limit:int revoke_time_limit:int revoke_pm_time_limit:int rating_e_decay:int stickers_recent_limit:int stickers_faved_limit:int channels_read_media_period:int tmp_sessions:flags.0?int pinned_dialogs_count_max:int pinned_infolder_count_max:int call_receive_timeout_ms:int call_ring_timeout_ms:int call_connect_timeout_ms:int call_packet_timeout_ms:int me_url_prefix:string autoupdate_url_prefix:flags.7?string gif_search_username:flags.9?string venue_search_username:flags.10?string img_search_username:flags.11?string static_maps_provider:flags.12?string caption_length_max:int message_length_max:int webfile_dc_id:int suggested_lang_code:flags.2?string lang_pack_version:flags.2?int base_lang_pack_version:flags.2?int reactions_default:flags.15?Reaction = Config;
 
 nearestDc#8e1a1775 country:string this_dc:int nearest_dc:int = NearestDc;
 
@@ -557,7 +561,7 @@ authorization#ad01d61d flags:# current:flags.0?true official_app:flags.1?true pa
 
 account.authorizations#4bff8ea0 authorization_ttl_days:int authorizations:Vector<Authorization> = account.Authorizations;
 
-account.password#185b184f flags:# has_recovery:flags.0?true has_secure_values:flags.1?true has_password:flags.2?true current_algo:flags.2?PasswordKdfAlgo srp_B:flags.2?bytes srp_id:flags.2?long hint:flags.3?string email_unconfirmed_pattern:flags.4?string new_algo:PasswordKdfAlgo new_secure_algo:SecurePasswordKdfAlgo secure_random:bytes pending_reset_date:flags.5?int = account.Password;
+account.password#957b50fb flags:# has_recovery:flags.0?true has_secure_values:flags.1?true has_password:flags.2?true current_algo:flags.2?PasswordKdfAlgo srp_B:flags.2?bytes srp_id:flags.2?long hint:flags.3?string email_unconfirmed_pattern:flags.4?string new_algo:PasswordKdfAlgo new_secure_algo:SecurePasswordKdfAlgo secure_random:bytes pending_reset_date:flags.5?int login_email_pattern:flags.6?string = account.Password;
 
 account.passwordSettings#9a5c33e5 flags:# email:flags.0?string secure_settings:flags.1?SecureSecretSettings = account.PasswordSettings;
 
@@ -581,6 +585,8 @@ inputStickerSetAnimatedEmoji#28703c8 = InputStickerSet;
 inputStickerSetDice#e67f520e emoticon:string = InputStickerSet;
 inputStickerSetAnimatedEmojiAnimations#cde3739 = InputStickerSet;
 inputStickerSetPremiumGifts#c88b3b02 = InputStickerSet;
+inputStickerSetEmojiGenericAnimations#4c4d4ce = InputStickerSet;
+inputStickerSetEmojiDefaultStatuses#29d0f5ee = InputStickerSet;
 
 stickerSet#2dd14edc flags:# archived:flags.1?true official:flags.2?true masks:flags.3?true animated:flags.5?true videos:flags.6?true emojis:flags.7?true installed_date:flags.0?int id:long access_hash:long title:string short_name:string thumbs:flags.4?Vector<PhotoSize> thumb_dc_id:flags.4?int thumb_version:flags.4?int thumb_document_id:flags.8?long count:int hash:int = StickerSet;
 
@@ -716,6 +722,8 @@ auth.sentCodeTypeSms#c000bba2 length:int = auth.SentCodeType;
 auth.sentCodeTypeCall#5353e5a7 length:int = auth.SentCodeType;
 auth.sentCodeTypeFlashCall#ab03c6d9 pattern:string = auth.SentCodeType;
 auth.sentCodeTypeMissedCall#82006484 prefix:string length:int = auth.SentCodeType;
+auth.sentCodeTypeEmailCode#5a159841 flags:# apple_signin_allowed:flags.0?true google_signin_allowed:flags.1?true email_pattern:string length:int next_phone_login_date:flags.2?int = auth.SentCodeType;
+auth.sentCodeTypeSetUpEmailRequired#a5491dea flags:# apple_signin_allowed:flags.0?true google_signin_allowed:flags.1?true = auth.SentCodeType;
 
 messages.botCallbackAnswer#36585ea4 flags:# alert:flags.1?true has_url:flags.3?true native_ui:flags.4?true message:flags.0?string url:flags.2?string cache_time:int = messages.BotCallbackAnswer;
 
@@ -850,6 +858,7 @@ inputWebDocument#9bed434d url:string size:int mime_type:string attributes:Vector
 
 inputWebFileLocation#c239d686 url:string access_hash:long = InputWebFileLocation;
 inputWebFileGeoPointLocation#9f2221c9 geo_point:InputGeoPoint access_hash:long w:int h:int zoom:int scale:int = InputWebFileLocation;
+inputWebFileAudioAlbumThumbLocation#f46fe924 flags:# small:flags.2?true document:flags.0?InputDocument title:flags.1?string performer:flags.1?string = InputWebFileLocation;
 
 upload.webFile#21e753bc size:int mime_type:string file_type:storage.FileType mtime:int bytes:bytes = upload.WebFile;
 
@@ -941,7 +950,7 @@ channelAdminLogEventActionChangeHistoryTTL#6e941a38 prev_value:int new_value:int
 channelAdminLogEventActionParticipantJoinByRequest#afb6144a invite:ExportedChatInvite approved_by:long = ChannelAdminLogEventAction;
 channelAdminLogEventActionToggleNoForwards#cb2ac766 new_value:Bool = ChannelAdminLogEventAction;
 channelAdminLogEventActionSendMessage#278f2868 message:Message = ChannelAdminLogEventAction;
-channelAdminLogEventActionChangeAvailableReactions#9cf7f76a prev_value:Vector<string> new_value:Vector<string> = ChannelAdminLogEventAction;
+channelAdminLogEventActionChangeAvailableReactions#be4e0ef8 prev_value:ChatReactions new_value:ChatReactions = ChannelAdminLogEventAction;
 
 channelAdminLogEvent#1fad68cd id:long date:int user_id:long action:ChannelAdminLogEventAction = ChannelAdminLogEvent;
 
@@ -1318,7 +1327,7 @@ searchResultPosition#7f648b67 msg_id:int date:int offset:int = SearchResultsPosi
 
 messages.searchResultsPositions#53b22baf count:int positions:Vector<SearchResultsPosition> = messages.SearchResultsPositions;
 
-channels.sendAsPeers#8356cda9 peers:Vector<Peer> chats:Vector<Chat> users:Vector<User> = channels.SendAsPeers;
+channels.sendAsPeers#f496b0c6 peers:Vector<SendAsPeer> chats:Vector<Chat> users:Vector<User> = channels.SendAsPeers;
 
 users.userFull#3b6d152e full_user:UserFull chats:Vector<Chat> users:Vector<User> = users.UserFull;
 
@@ -1326,7 +1335,7 @@ messages.peerSettings#6880b94d settings:PeerSettings chats:Vector<Chat> users:Ve
 
 auth.loggedOut#c3a2835f flags:# future_auth_token:flags.0?bytes = auth.LoggedOut;
 
-reactionCount#6fb250d1 flags:# chosen:flags.0?true reaction:string count:int = ReactionCount;
+reactionCount#a3d1cb80 flags:# chosen_order:flags.0?int reaction:Reaction count:int = ReactionCount;
 
 messageReactions#4f2b9479 flags:# min:flags.0?true can_see_list:flags.2?true results:Vector<ReactionCount> recent_reactions:flags.1?Vector<MessagePeerReaction> = MessageReactions;
 
@@ -1340,7 +1349,7 @@ messages.availableReactions#768e3aad hash:int reactions:Vector<AvailableReaction
 messages.translateNoResult#67ca4737 = messages.TranslatedText;
 messages.translateResultText#a214f7d0 text:string = messages.TranslatedText;
 
-messagePeerReaction#51b67eff flags:# big:flags.0?true unread:flags.1?true peer_id:Peer reaction:string = MessagePeerReaction;
+messagePeerReaction#b156fe9c flags:# big:flags.0?true unread:flags.1?true peer_id:Peer reaction:Reaction = MessagePeerReaction;
 
 groupCallStreamChannel#80eb48af channel:int scale:int last_timestamp_ms:long = GroupCallStreamChannel;
 
@@ -1393,7 +1402,7 @@ payments.exportedInvoice#aed0cbd9 url:string = payments.ExportedInvoice;
 
 messages.transcribedAudio#93752c52 flags:# pending:flags.0?true transcription_id:long text:string = messages.TranscribedAudio;
 
-help.premiumPromo#8a4f3c29 status_text:string status_entities:Vector<MessageEntity> video_sections:Vector<string> videos:Vector<Document> currency:string monthly_amount:long users:Vector<User> = help.PremiumPromo;
+help.premiumPromo#5334759c status_text:string status_entities:Vector<MessageEntity> video_sections:Vector<string> videos:Vector<Document> period_options:Vector<PremiumSubscriptionOption> users:Vector<User> = help.PremiumPromo;
 
 inputStorePaymentPremiumSubscription#a6751e66 flags:# restore:flags.0?true = InputStorePaymentPurpose;
 inputStorePaymentGiftPremium#616f7fe8 user_id:InputUser currency:string amount:long = InputStorePaymentPurpose;
@@ -1401,6 +1410,39 @@ inputStorePaymentGiftPremium#616f7fe8 user_id:InputUser currency:string amount:l
 premiumGiftOption#74c34319 flags:# months:int currency:string amount:long bot_url:string store_product:flags.0?string = PremiumGiftOption;
 
 paymentFormMethod#88f8f21b url:string title:string = PaymentFormMethod;
+
+emojiStatusEmpty#2de11aae = EmojiStatus;
+emojiStatus#929b619d document_id:long = EmojiStatus;
+emojiStatusUntil#fa30a8c7 document_id:long until:int = EmojiStatus;
+
+account.emojiStatusesNotModified#d08ce645 = account.EmojiStatuses;
+account.emojiStatuses#90c467d1 hash:long statuses:Vector<EmojiStatus> = account.EmojiStatuses;
+
+reactionEmpty#79f5d419 = Reaction;
+reactionEmoji#1b2286b8 emoticon:string = Reaction;
+reactionCustomEmoji#8935fc73 document_id:long = Reaction;
+
+chatReactionsNone#eafc32bc = ChatReactions;
+chatReactionsAll#52928bca flags:# allow_custom:flags.0?true = ChatReactions;
+chatReactionsSome#661d4037 reactions:Vector<Reaction> = ChatReactions;
+
+messages.reactionsNotModified#b06fdbdf = messages.Reactions;
+messages.reactions#eafdf716 hash:long reactions:Vector<Reaction> = messages.Reactions;
+
+emailVerifyPurposeLoginSetup#4345be73 phone_number:string phone_code_hash:string = EmailVerifyPurpose;
+emailVerifyPurposeLoginChange#527d22eb = EmailVerifyPurpose;
+emailVerifyPurposePassport#bbf51685 = EmailVerifyPurpose;
+
+emailVerificationCode#922e55a9 code:string = EmailVerification;
+emailVerificationGoogle#db909ec2 token:string = EmailVerification;
+emailVerificationApple#96d074fd token:string = EmailVerification;
+
+account.emailVerified#2b96cd1b email:string = account.EmailVerified;
+account.emailVerifiedLogin#e1bb0d61 email:string sent_code:auth.SentCode = account.EmailVerified;
+
+premiumSubscriptionOption#b6f11ebe flags:# current:flags.1?true can_purchase_upgrade:flags.2?true months:int currency:string amount:long bot_url:string store_product:flags.0?string = PremiumSubscriptionOption;
+
+sendAsPeer#b81c7034 flags:# premium_required:flags.0?true peer:Peer = SendAsPeer;
 
 ---functions---
 
@@ -1414,7 +1456,7 @@ invokeWithTakeout#aca9fd2e {X:Type} takeout_id:long query:!X = X;
 
 auth.sendCode#a677244f phone_number:string api_id:int api_hash:string settings:CodeSettings = auth.SentCode;
 auth.signUp#80eee427 phone_number:string phone_code_hash:string first_name:string last_name:string = auth.Authorization;
-auth.signIn#bcd51581 phone_number:string phone_code_hash:string phone_code:string = auth.Authorization;
+auth.signIn#8d52a951 flags:# phone_number:string phone_code_hash:string phone_code:flags.0?string email_verification:flags.1?EmailVerification = auth.Authorization;
 auth.logOut#3e72ba19 = auth.LoggedOut;
 auth.resetAuthorizations#9fab0d1a = Bool;
 auth.exportAuthorization#e5bfffcd dc_id:int = auth.ExportedAuthorization;
@@ -1470,8 +1512,8 @@ account.getAuthorizationForm#a929597a bot_id:long scope:string public_key:string
 account.acceptAuthorization#f3ed4c73 bot_id:long scope:string public_key:string value_hashes:Vector<SecureValueHash> credentials:SecureCredentialsEncrypted = Bool;
 account.sendVerifyPhoneCode#a5a356f9 phone_number:string settings:CodeSettings = auth.SentCode;
 account.verifyPhone#4dd3a7f6 phone_number:string phone_code_hash:string phone_code:string = Bool;
-account.sendVerifyEmailCode#7011509f email:string = account.SentEmailCode;
-account.verifyEmail#ecba39db email:string code:string = Bool;
+account.sendVerifyEmailCode#98e037bb purpose:EmailVerifyPurpose email:string = account.SentEmailCode;
+account.verifyEmail#32da4cf purpose:EmailVerifyPurpose verification:EmailVerification = account.EmailVerified;
 account.initTakeoutSession#8ef3eab0 flags:# contacts:flags.0?true message_users:flags.1?true message_chats:flags.2?true message_megagroups:flags.3?true message_channels:flags.4?true files:flags.5?true file_max_size:flags.5?long = account.Takeout;
 account.finishTakeoutSession#1d2652ee flags:# success:flags.0?true = Bool;
 account.confirmPasswordEmail#8fdf1920 code:string = Bool;
@@ -1508,6 +1550,10 @@ account.changeAuthorizationSettings#40f48462 flags:# hash:long encrypted_request
 account.getSavedRingtones#e1902288 hash:long = account.SavedRingtones;
 account.saveRingtone#3dea5b03 id:InputDocument unsave:Bool = account.SavedRingtone;
 account.uploadRingtone#831a83a2 file:InputFile file_name:string mime_type:string = Document;
+account.updateEmojiStatus#fbd3de6b emoji_status:EmojiStatus = Bool;
+account.getDefaultEmojiStatuses#d6753386 hash:long = account.EmojiStatuses;
+account.getRecentEmojiStatuses#f578105 hash:long = account.EmojiStatuses;
+account.clearRecentEmojiStatuses#18201aae = Bool;
 
 users.getUsers#d91a548 id:Vector<InputUser> = Vector<User>;
 users.getFullUser#b60f5918 id:InputUser = users.UserFull;
@@ -1544,8 +1590,8 @@ messages.deleteHistory#b08f922a flags:# just_clear:flags.0?true revoke:flags.1?t
 messages.deleteMessages#e58e95d2 flags:# revoke:flags.0?true id:Vector<int> = messages.AffectedMessages;
 messages.receivedMessages#5a954c0 max_id:int = Vector<ReceivedNotifyMessage>;
 messages.setTyping#58943ee2 flags:# peer:InputPeer top_msg_id:flags.0?int action:SendMessageAction = Bool;
-messages.sendMessage#d9d75a4 flags:# no_webpage:flags.1?true silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true peer:InputPeer reply_to_msg_id:flags.0?int message:string random_id:long reply_markup:flags.2?ReplyMarkup entities:flags.3?Vector<MessageEntity> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
-messages.sendMedia#e25ff8e0 flags:# silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true peer:InputPeer reply_to_msg_id:flags.0?int media:InputMedia message:string random_id:long reply_markup:flags.2?ReplyMarkup entities:flags.3?Vector<MessageEntity> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
+messages.sendMessage#d9d75a4 flags:# no_webpage:flags.1?true silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true update_stickersets_order:flags.15?true peer:InputPeer reply_to_msg_id:flags.0?int message:string random_id:long reply_markup:flags.2?ReplyMarkup entities:flags.3?Vector<MessageEntity> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
+messages.sendMedia#e25ff8e0 flags:# silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true update_stickersets_order:flags.15?true peer:InputPeer reply_to_msg_id:flags.0?int media:InputMedia message:string random_id:long reply_markup:flags.2?ReplyMarkup entities:flags.3?Vector<MessageEntity> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
 messages.forwardMessages#cc30290b flags:# silent:flags.5?true background:flags.6?true with_my_score:flags.8?true drop_author:flags.11?true drop_media_captions:flags.12?true noforwards:flags.14?true from_peer:InputPeer id:Vector<int> random_id:Vector<long> to_peer:InputPeer schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
 messages.reportSpam#cf1592db peer:InputPeer = Bool;
 messages.getPeerSettings#efd9a6a2 peer:InputPeer = messages.PeerSettings;
@@ -1625,7 +1671,7 @@ messages.faveSticker#b9ffc55b id:InputDocument unfave:Bool = Bool;
 messages.getUnreadMentions#46578472 peer:InputPeer offset_id:int add_offset:int limit:int max_id:int min_id:int = messages.Messages;
 messages.readMentions#f0189d3 peer:InputPeer = messages.AffectedHistory;
 messages.getRecentLocations#702a40e0 peer:InputPeer limit:int hash:long = messages.Messages;
-messages.sendMultiMedia#f803138f flags:# silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true peer:InputPeer reply_to_msg_id:flags.0?int multi_media:Vector<InputSingleMedia> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
+messages.sendMultiMedia#f803138f flags:# silent:flags.5?true background:flags.6?true clear_draft:flags.7?true noforwards:flags.14?true update_stickersets_order:flags.15?true peer:InputPeer reply_to_msg_id:flags.0?int multi_media:Vector<InputSingleMedia> schedule_date:flags.10?int send_as:flags.13?InputPeer = Updates;
 messages.uploadEncryptedFile#5057c497 peer:InputEncryptedChat file:InputEncryptedFile = EncryptedFile;
 messages.searchStickerSets#35705b8a flags:# exclude_featured:flags.0?true q:string hash:long = messages.FoundStickerSets;
 messages.getSplitRanges#1cff7e08 = Vector<MessageRange>;
@@ -1684,12 +1730,12 @@ messages.hideChatJoinRequest#7fe7e815 flags:# approved:flags.0?true peer:InputPe
 messages.hideAllChatJoinRequests#e085f4ea flags:# approved:flags.0?true peer:InputPeer link:flags.1?string = Updates;
 messages.toggleNoForwards#b11eafa2 peer:InputPeer enabled:Bool = Updates;
 messages.saveDefaultSendAs#ccfddf96 peer:InputPeer send_as:InputPeer = Bool;
-messages.sendReaction#25690ce4 flags:# big:flags.1?true peer:InputPeer msg_id:int reaction:flags.0?string = Updates;
+messages.sendReaction#d30d78d4 flags:# big:flags.1?true add_to_recent:flags.2?true peer:InputPeer msg_id:int reaction:flags.0?Vector<Reaction> = Updates;
 messages.getMessagesReactions#8bba90e6 peer:InputPeer id:Vector<int> = Updates;
-messages.getMessageReactionsList#e0ee6b77 flags:# peer:InputPeer id:int reaction:flags.0?string offset:flags.1?string limit:int = messages.MessageReactionsList;
-messages.setChatAvailableReactions#14050ea6 peer:InputPeer available_reactions:Vector<string> = Updates;
+messages.getMessageReactionsList#461b3f48 flags:# peer:InputPeer id:int reaction:flags.0?Reaction offset:flags.1?string limit:int = messages.MessageReactionsList;
+messages.setChatAvailableReactions#feb16771 peer:InputPeer available_reactions:ChatReactions = Updates;
 messages.getAvailableReactions#18dea0ac hash:int = messages.AvailableReactions;
-messages.setDefaultReaction#d960c4d4 reaction:string = Bool;
+messages.setDefaultReaction#4f47a016 reaction:Reaction = Bool;
 messages.translateText#24ce6dee flags:# peer:flags.0?InputPeer msg_id:flags.0?int text:flags.1?string from_lang:flags.2?string to_lang:string = messages.TranslatedText;
 messages.getUnreadReactions#e85bae1a peer:InputPeer offset_id:int add_offset:int limit:int max_id:int min_id:int = messages.Messages;
 messages.readReactions#82e251d7 peer:InputPeer = messages.AffectedHistory;
@@ -1697,9 +1743,9 @@ messages.searchSentMedia#107e31a0 q:string filter:MessagesFilter limit:int = mes
 messages.getAttachMenuBots#16fcc2cb hash:long = AttachMenuBots;
 messages.getAttachMenuBot#77216192 bot:InputUser = AttachMenuBotsBot;
 messages.toggleBotInAttachMenu#1aee33af bot:InputUser enabled:Bool = Bool;
-messages.requestWebView#91b15831 flags:# from_bot_menu:flags.4?true silent:flags.5?true peer:InputPeer bot:InputUser url:flags.1?string start_param:flags.3?string theme_params:flags.2?DataJSON reply_to_msg_id:flags.0?int send_as:flags.13?InputPeer = WebViewResult;
+messages.requestWebView#fc87a53c flags:# from_bot_menu:flags.4?true silent:flags.5?true peer:InputPeer bot:InputUser url:flags.1?string start_param:flags.3?string theme_params:flags.2?DataJSON platform:string reply_to_msg_id:flags.0?int send_as:flags.13?InputPeer = WebViewResult;
 messages.prolongWebView#ea5fbcce flags:# silent:flags.5?true peer:InputPeer bot:InputUser query_id:long reply_to_msg_id:flags.0?int send_as:flags.13?InputPeer = Bool;
-messages.requestSimpleWebView#6abb2f73 flags:# bot:InputUser url:string theme_params:flags.0?DataJSON = SimpleWebViewResult;
+messages.requestSimpleWebView#299bec8e flags:# bot:InputUser url:string theme_params:flags.0?DataJSON platform:string = SimpleWebViewResult;
 messages.sendWebViewResultMessage#a4314f5 bot_query_id:string result:InputBotInlineResult = WebViewMessageSent;
 messages.sendWebViewData#dc0242c8 bot:InputUser random_id:long button_text:string data:string = Updates;
 messages.transcribeAudio#269e9a49 peer:InputPeer msg_id:int = messages.TranscribedAudio;
@@ -1707,6 +1753,10 @@ messages.rateTranscribedAudio#7f1d072f peer:InputPeer msg_id:int transcription_i
 messages.getCustomEmojiDocuments#d9ab0f54 document_id:Vector<long> = Vector<Document>;
 messages.getEmojiStickers#fbfca18f hash:long = messages.AllStickers;
 messages.getFeaturedEmojiStickers#ecf6736 hash:long = messages.FeaturedStickers;
+messages.reportReaction#3f64c076 peer:InputPeer id:int reaction_peer:InputPeer = Bool;
+messages.getTopReactions#bb8125ba limit:int hash:long = messages.Reactions;
+messages.getRecentReactions#39461db2 limit:int hash:long = messages.Reactions;
+messages.clearRecentReactions#9dfeefb4 = Bool;
 
 updates.getState#edd4882a = updates.State;
 updates.getDifference#25939651 flags:# pts:int pts_total_limit:flags.0?int date:int qts:int = updates.Difference;
@@ -1813,7 +1863,6 @@ payments.exportInvoice#f91b065 invoice_media:InputMedia = payments.ExportedInvoi
 payments.assignAppStoreTransaction#80ed747d receipt:bytes purpose:InputStorePaymentPurpose = Updates;
 payments.assignPlayMarketTransaction#dffd50d3 receipt:DataJSON purpose:InputStorePaymentPurpose = Updates;
 payments.canPurchasePremium#9fc19eb6 purpose:InputStorePaymentPurpose = Bool;
-payments.requestRecurringPayment#146e958d user_id:InputUser recurring_init_charge:string invoice_media:InputMedia = Updates;
 
 stickers.createStickerSet#9021ab67 flags:# masks:flags.0?true animated:flags.1?true videos:flags.4?true user_id:InputUser title:string short_name:string thumb:flags.2?InputDocument stickers:Vector<InputStickerSetItem> software:flags.3?string = messages.StickerSet;
 stickers.removeStickerFromSet#f7760f51 sticker:InputDocument = messages.StickerSet;
@@ -1870,4 +1919,4 @@ stats.getMegagroupStats#dcdf8607 flags:# dark:flags.0?true channel:InputChannel 
 stats.getMessagePublicForwards#5630281b channel:InputChannel msg_id:int offset_rate:int offset_peer:InputPeer offset_id:int limit:int = messages.Messages;
 stats.getMessageStats#b6e0a3f5 flags:# dark:flags.0?true channel:InputChannel msg_id:int = stats.MessageStats;
 
-// LAYER 144
+// LAYER 145

--- a/telethon_generator/data/errors.csv
+++ b/telethon_generator/data/errors.csv
@@ -438,3 +438,5 @@ WORKER_BUSY_TOO_LONG_RETRY,500,Telegram workers are too busy to respond immediat
 YOU_BLOCKED_USER,400,You blocked this user
 PREMIUM_ACCOUNT_REQUIRED,403,Telegram Premium is required to use this feature
 MSG_VOICE_TOO_LONG,400,Voice message is too big to recognize
+VOICE_MESSAGES_FORBIDDEN,400,User have forbidden to receive voice messages
+MSG_VOICE_MISSING,400,There is no voice in message to transcribe


### PR DESCRIPTION
- Add :method:`telethon.TelegramClient.set_status`
- Add :method:`telethon.TelegramClient.report_reaction`
- Add :method:`telethon.TelegramClient.transcribe`
- Add :method:`telethon.TelegramClient.translate`
- Add :method:`telethon.TelegramClient.send_email_code`
- Add :method:`telethon.TelegramClient.verify_email`
- Add :method:`telethon.utils.convert_reaction`
- Add :obj:`telethon.hints.Reaction`
- Add :obj:`telethon.hints.DialogLike`
- Add :method:`telethon.tl.custom.message.Message.translate`
- Add :method:`telethon.tl.custom.message.Message.transcribe`
- Add reaction converter to :method:`telethon.TelegramClient.send_reaction`, :method:`telethon.TelegramClient.set_quick_reaction`, :method:`telethon.tl.custom.message.Message.react`
- Add :param:`add_to_recent: bool` to :method:`telethon.TelegramClient.send_reaction`
- Add :param:`add_to_recent: bool` to :method:`telethon.tl.custom.message.Message.react`
- Add :param:`email_code: str` to :method:`telethon.TelegramClient.sign_in`
- Add outer entity removal for custom emojis in :obj:`telethon.extensions.html.TextDecoration`
- Add :obj:`telethon.errors.rpcerrorlist.VoiceMessagesForbiddenError`
- Add :obj:`telethon.errors.rpcerrorlist.MsgVoiceMissingError`
- Make attribute `document_id` of custom emoji entity :type:`int`, from :type:`str`
- Update API layer to 145